### PR TITLE
Keyring usage is now optional

### DIFF
--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Build Tools
         run: |
           pip install --upgrade build twine
-          pip install urllib3==1.26.15 --force-reinstall
+          # pip install urllib3==1.26.15 --force-reinstall
       - name: Publish Package
         run: |
           python -m build

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Build Tools
         run: |
           pip install --upgrade build twine

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -12,7 +12,6 @@ jobs:
       - name: Install Build Tools
         run: |
           pip install --upgrade build twine
-          # pip install urllib3==1.26.15 --force-reinstall
       - name: Publish Package
         run: |
           python -m build

--- a/.github/workflows/release_and_publish.yaml
+++ b/.github/workflows/release_and_publish.yaml
@@ -16,13 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create Release
         run: gh release create v${{ github.event.inputs.version }} --generate-notes
       - name: Install Build Tools
         run: |
           pip install --upgrade build twine
-          pip install urllib3==1.26.15 --force-reinstall
       - name: Publish Package
         run: |
           python -m build

--- a/README.md
+++ b/README.md
@@ -88,9 +88,29 @@ options:
 
 ## Troubleshooting
 
+### Clear Saved Password
+
 If you receive an error indicating that there's no valid SAML assertation, please double check your config settings. If you have keyring enabled, you may have stored
-an incorrect password. To reset your keyring password, run the following command:
+an incorrect password. To reset your keyring password, run one of the following commands:
 
 ```text
 macaw-auth -r
 ```
+
+or
+
+```text
+macaw-auth --reset-password
+```
+
+### Errors Running the Utility With Keyring Enabled
+
+This utility gives the option to use [Keyring](https://pypi.org/project/keyring/) to locally store your password. If you attempt to use Keyring and do not have a proper backend set up as stated in the Keyring documentation, macaw-auth may not work. To disable Keyring, use one of the following options:
+
+#### 1. **Disable Keyring in Config File**
+
+In your config file, you can set ```enable_keyring = False``` in the **[macaw-auth]** section
+
+#### 2. **Disable Keyring via CLI**
+
+When running macaw-auth commands, you can add the **--disable-keyring** flag (e.g., ```macaw-auth --disable-keyring```).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macaw-auth"
-version = "1.0.0"
+version = "1.1.0"
 description = "Tool to obtain AWS CLI credentials from ADFS."
 readme = "README.md"
 authors = [

--- a/src/macaw_auth/cli/__main__.py
+++ b/src/macaw_auth/cli/__main__.py
@@ -29,13 +29,14 @@ def get_username(name: str) -> str:
 
 def main() -> None:
     args = cli_main()
+    #FOR DEBUGGING
     # print(args)
 
     print('Welcome! Checking your configuration files...')
     client_config = Configuration('client', 'macaw-auth',
                            session_duration=(arg_to_string(args['duration_seconds']),False, '3600'),
                            identity_url=(arg_to_string(args['identity_url']),True, ''),
-                           enable_keyring=(arg_to_string(args['keyring']),False, 'True'),
+                           enable_keyring=(arg_to_string(args['enable_keyring']),False, 'False'),
                            username=(None, False, ''))
     client = client_config.config[client_config.config_section]
     role_config = Configuration('user', arg_to_string(args['SOURCE_PROFILE']),
@@ -48,9 +49,8 @@ def main() -> None:
 
     user = get_username(client['username'])
     validation = UsernameValidation(user, args['username_not_email'])
-    user_creds = UserCredentials(validation.username, args['reset_password'], client['enable_keyring'])
-    assertion = SAMLAssertion(validation.username, user_creds.get_keyring_password(), client['identity_url'], args['auth_type'], args['no_ssl'])
-    roles = AWSSTSService(assertion.assertion, role['principal_arn'], role['role_arn'], int(client['session_duration']), role['region'])
+    user_creds = UserCredentials(validation.username, client['identity_url'], args['auth_type'], args['no_ssl'], args['reset_password'], client['enable_keyring'])
+    roles = AWSSTSService(user_creds.assertion, role['principal_arn'], role['role_arn'], int(client['session_duration']), role['region'])
 
 
     aws_creds = AWSCredentials('credential', arg_to_string(args['target_profile']),

--- a/src/macaw_auth/cli/cli.py
+++ b/src/macaw_auth/cli/cli.py
@@ -32,7 +32,7 @@ def main():
     parser.add_argument('-a', '--auth-type', help='Authorization type used for SAML request', choices=['ntlm', 'web_form'], nargs='?', default='web_form')
     parser.add_argument('--duration-seconds', help="Length of time in seconds in which credentials are valid", type=int)
     parser.add_argument('--identity-url', help='URL used to initiate SAML request')
-    parser.add_argument('--disable-keyring', action='store_false', help='Disable storing password in keyring', dest='keyring')
+    parser.add_argument('--disable-keyring', action='store_const', help='Disable storing password in keyring', const=False, dest='enable_keyring')
     parser.add_argument('--region', help='Default AWS region for CLI commands')
     parser.add_argument('--output', help='The desired AWS CLI output format', choices=['json', 'yaml', 'yaml-stream', 'text', 'table'])
     parser.add_argument('--role-arn', help='ARN of the role that you want to assume')


### PR DESCRIPTION
The previous version of this utility required the use of Keyring access your password. This has caused issues for some macOS and Linux systems if they did not have an appropriate Keyring backend configured. Keyring can now be disabled so this issue can be bypassed.

This PR resolves issue #5 