### PR TITLE
Allow ability to ignore SSL verification errors on login function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macaw-auth"
-version = "2.0.1"
+version = "2.1.0"
 description = "Utility to authenticate to AWS Services via CLI using ADFS"
 readme = "README.md"
 authors = [

--- a/src/macaw_auth/classes/sts_saml.py
+++ b/src/macaw_auth/classes/sts_saml.py
@@ -8,10 +8,12 @@ from macaw_auth.functions.common import arn_validation
 
 class AWSSTSService:
 
-    def __init__(self, region="us-east-1", access_key=None, secret_key=None, session_token=None):
+    def __init__(self, region="us-east-1", access_key=None, secret_key=None, session_token=None,
+                 verify_ssl=True):
         self.region = region
         self.sts = boto3.client('sts', region_name=self.region, aws_access_key_id=access_key,
-                                aws_secret_access_key=secret_key, aws_session_token=session_token)
+                                aws_secret_access_key=secret_key, aws_session_token=session_token,
+                                verify=verify_ssl)
 
     def login(self, account_number, idp_name, role_name, saml_assertion, target_profile, credential_file,
               partition="aws", path="/", session_duration=3600, output_format="json"):

--- a/src/macaw_auth/functions/login.py
+++ b/src/macaw_auth/functions/login.py
@@ -29,7 +29,7 @@ def main(args) -> None:
         "output": (args['output'], False, 'json'),
         "connection_type": (args['auth_type'], False, 'web_form'),
         "path": (args['path'], False, '/'),
-        "partition": (args['partition'], False, 'aws')
+        "partition": (args['partition'], False, 'aws'),
     }
 
     print('Welcome! Checking your configuration files...')
@@ -41,7 +41,7 @@ def main(args) -> None:
     user_creds = UserCredentials(validation.username, client['identity_url'],
                                 args['auth_type'], args['no_ssl'],
                                 args['reset_password'], client['enable_keyring'])
-    sts_service = AWSSTSService(client['region'])
+    sts_service = AWSSTSService(client['region'],verify_ssl=args['no_ssl'])
     sts_service.login(client['account_number'], client['idp_name'], client['role_name'],
                       user_creds.assertion, args['target_profile'], args['credential_file'],
                       client['partition'], client['path'], int(client['session_duration']),


### PR DESCRIPTION
The "--no-ssl-verify" flag was not working so adjusted the code to allow it to work as intended. Ignoring SSL verification is not recommended, but the feature is added in case it is needed.